### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Model Context Protocol (MCP) server that provides tools for interacting with C
 
 [![CI/CD Pipeline](https://github.com/aaronsb/confluence-cloud-mcp/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/aaronsb/confluence-cloud-mcp/actions/workflows/ci-cd.yml)
 
+<a href="https://glama.ai/mcp/servers/mp9zjz01wb"><img width="380" height="200" src="https://glama.ai/mcp/servers/mp9zjz01wb/badge" alt="Confluence Server MCP server" /></a>
+
 ## Features
 
 - Space Management


### PR DESCRIPTION
This PR adds a badge for the [Confluence MCP Server](https://glama.ai/mcp/servers/mp9zjz01wb) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/mp9zjz01wb"><img width="380" height="200" src="https://glama.ai/mcp/servers/mp9zjz01wb/badge" alt="Confluence Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.